### PR TITLE
Add ts parameter checking in mark-all-as-read

### DIFF
--- a/src/api/tag.js
+++ b/src/api/tag.js
@@ -115,7 +115,7 @@ app.post('/reader/api/0/mark-all-as-read', function(req, res) {
     // Get all of the posts in the stream
     // Google Reader appears to only accept a single stream
     var tag = db.findOrCreate(db.Tag, tag);
-    var posts = db.postsForStreams(streams);
+    
     
     // Check if the timestamp parameter is set.
     // If so, add to postsForStreams options.
@@ -126,6 +126,8 @@ app.post('/reader/api/0/mark-all-as-read', function(req, res) {
         };
         console.log('Check ts: ' + req.body.ts);
     }
+    
+    var posts = db.postsForStreams(streams, options);
     
     rsvp.all([tag, posts]).then(function(results) {
         var tag = results[0], posts = results[1];

--- a/src/api/tag.js
+++ b/src/api/tag.js
@@ -117,6 +117,16 @@ app.post('/reader/api/0/mark-all-as-read', function(req, res) {
     var tag = db.findOrCreate(db.Tag, tag);
     var posts = db.postsForStreams(streams);
     
+    // Check if the timestamp parameter is set.
+    // If so, add to postsForStreams options.
+    var options = {};
+    if (req.body.ts) {
+        options = {
+            maxTime: req.body.ts
+        };
+        console.log('Check ts: ' + req.body.ts);
+    }
+    
     rsvp.all([tag, posts]).then(function(results) {
         var tag = results[0], posts = results[1];
         


### PR DESCRIPTION
Current Google Reader API has a ts parameter for mark-all-as-read, which uses to mark items that are older than the given ts as read.
